### PR TITLE
Fix Syntax of String Returned by `getColor`

### DIFF
--- a/src/lib/Confetti.svelte
+++ b/src/lib/Confetti.svelte
@@ -32,7 +32,7 @@
 
   function getColor() {
     if (colorArray.length) return colorArray[Math.round(Math.random() * (colorArray.length - 1))]
-    else return `hsl(${Math.round(randomBetween(colorRange[0], colorRange[1]))}, 75%, 50%`
+    else return `hsl(${Math.round(randomBetween(colorRange[0], colorRange[1]))}, 75%, 50%)`
   }
 </script>
 


### PR DESCRIPTION
The `getColor` function returns an `hsl()` color calculation but doesn't include a closing `)` to the function call.  This somehow works in Svelte 4 but starts breaking with Svelte 5.

- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/Mitcheljager/svelte-confetti/pull/10)